### PR TITLE
Improve exception handling with Rcpp macros

### DIFF
--- a/src/dmixtCpp.cpp
+++ b/src/dmixtCpp.cpp
@@ -38,9 +38,9 @@ RcppExport SEXP dmixtCpp(SEXP X_,
                          SEXP isChol_, 
                          SEXP A_) 
 { 
+  BEGIN_RCPP
   using namespace Rcpp;
   
-  try{
     arma::mat X = as<arma::mat>(X_);
     arma::mat mu = as<arma::mat>(mu_);  
     List sigma = List(sigma_);
@@ -122,11 +122,6 @@ RcppExport SEXP dmixtCpp(SEXP X_,
     
     return Rout;
     
-  } catch( std::exception& __ex__){
-    forward_exception_to_r(__ex__);
-  } catch(...){
-    Rcpp::stop( "c++ exception (unknown reason)" );
-  }
-  return wrap(NA_REAL);
+  END_RCPP
 }
 

--- a/src/dmvtCpp.cpp
+++ b/src/dmvtCpp.cpp
@@ -36,9 +36,9 @@ USA. */
                           SEXP ncores_,
                           SEXP isChol_) 
 { 
+  BEGIN_RCPP
   using namespace Rcpp;
   
-  try{
     arma::mat X = as<arma::mat>(X_);
     arma::vec mu = as<arma::vec>(mu_);  
     arma::mat sigma = as<arma::mat>(sigma_); 
@@ -78,13 +78,8 @@ USA. */
     
     return Rout;
     
-  } catch( std::exception& __ex__){
-    forward_exception_to_r(__ex__);
-  } catch(...){
-    Rcpp::stop( "c++ exception (unknown reason)" );
-  }
-  return wrap(NA_REAL);
-  }
+  END_RCPP
+}
 
 
 /* 

--- a/src/mahaCpp.cpp
+++ b/src/mahaCpp.cpp
@@ -30,10 +30,9 @@ USA. */
  */
 RcppExport SEXP mahaCpp(SEXP X, SEXP mu, SEXP sigma, SEXP ncores, SEXP isChol)
 {
+    BEGIN_RCPP
     using namespace Rcpp;
     
-    try{
-      
       arma::mat X_ = as<arma::mat>(X);
       arma::vec mu_ = as<arma::vec>(mu);  
       arma::mat sigma_ = as<arma::mat>(sigma); 
@@ -56,12 +55,7 @@ RcppExport SEXP mahaCpp(SEXP X, SEXP mu, SEXP sigma, SEXP ncores, SEXP isChol)
       
       return dist;
       
-    } catch( std::exception& __ex__){
-      forward_exception_to_r(__ex__);
-    } catch(...){
-      Rcpp::stop( "c++ exception (unknown reason)" );
-    }
-    return wrap(NA_REAL);
+    END_RCPP
 }
   
 

--- a/src/msCpp.cpp
+++ b/src/msCpp.cpp
@@ -28,10 +28,9 @@ USA. */
 
 RcppExport SEXP msCpp(SEXP init_, SEXP X_, SEXP cholDec_, SEXP ncores_, SEXP tol_, SEXP store_)
 {
+    BEGIN_RCPP
     using namespace Rcpp;
     
-    try{
-      
       arma::vec init = as<arma::vec>(init_);
       arma::mat X = as<arma::mat>(X_); 
       arma::mat cholDec = as<arma::mat>(cholDec_); 
@@ -78,10 +77,5 @@ RcppExport SEXP msCpp(SEXP init_, SEXP X_, SEXP cholDec_, SEXP ncores_, SEXP tol
             
       return List::create( _["final"] = wrap( currPos ), _["traj"] = wrap( traj ) );
       
-    } catch( std::exception& __ex__){
-      forward_exception_to_r(__ex__);
-    } catch(...){
-      Rcpp::stop( "c++ exception (unknown reason)" );
-    }
-    return wrap(NA_REAL);
+    END_RCPP
 }

--- a/src/rmixnCpp.cpp
+++ b/src/rmixnCpp.cpp
@@ -34,10 +34,9 @@ RcppExport SEXP rmixnCpp(SEXP n_,
                          SEXP retInd_,
                          SEXP A_) 
 { 
+  BEGIN_RCPP
   using namespace Rcpp;
   
-  try{
-    
     uint32_t n = as<uint32_t>(n_);
     arma::mat mu = as<arma::mat>(mu_);  
     List sigma = List(sigma_);
@@ -165,10 +164,5 @@ RcppExport SEXP rmixnCpp(SEXP n_,
 
   return R_NilValue;
 
-  } catch( std::exception& __ex__){
-    forward_exception_to_r(__ex__);
-  } catch(...){
-    Rcpp::stop( "c++ exception (unknown reason)" );
-  }
-  return wrap(NA_REAL);
+  END_RCPP
 }

--- a/src/rmixtCpp.cpp
+++ b/src/rmixtCpp.cpp
@@ -35,10 +35,9 @@ RcppExport SEXP rmixtCpp(SEXP n_,
                          SEXP retInd_,
                          SEXP A_)  
 { 
+  BEGIN_RCPP
   using namespace Rcpp;
   
-  try{
-    
     uint32_t n = as<uint32_t>(n_);
     arma::mat mu = as<arma::mat>(mu_);  
     List sigma = List(sigma_);
@@ -170,10 +169,5 @@ omp_set_num_threads(ncores_0);
 
 return R_NilValue;
 
-  } catch( std::exception& __ex__){
-    forward_exception_to_r(__ex__);
-  } catch(...){
-    Rcpp::stop( "c++ exception (unknown reason)" );
-  }
-  return wrap(NA_REAL);
+  END_RCPP
 }

--- a/src/rmvnCpp.cpp
+++ b/src/rmvnCpp.cpp
@@ -32,10 +32,9 @@ RcppExport SEXP rmvnCpp(SEXP n_,
                         SEXP isChol_, 
                         SEXP A_) 
 { 
+    BEGIN_RCPP
     using namespace Rcpp;
     
-    try{
-      
       uint32_t n = as<uint32_t>(n_);
       arma::rowvec mu = as<arma::rowvec>(mu_);  
       arma::mat sigma = as<arma::mat>(sigma_); 
@@ -146,10 +145,5 @@ RcppExport SEXP rmvnCpp(SEXP n_,
       
       return R_NilValue;
             
-    } catch( std::exception& __ex__){
-      forward_exception_to_r(__ex__);
-    } catch(...){
-      Rcpp::stop( "c++ exception (unknown reason)" );
-    }
-    return wrap(NA_REAL);
+    END_RCPP
 }

--- a/src/rmvtCpp.cpp
+++ b/src/rmvtCpp.cpp
@@ -33,10 +33,9 @@ RcppExport SEXP rmvtCpp(SEXP n_,
                         SEXP isChol_, 
                         SEXP A_) 
 { 
+  BEGIN_RCPP
   using namespace Rcpp;
   
-  try{
-    
     uint32_t n = as<uint32_t>(n_);
     arma::rowvec mu = as<arma::rowvec>(mu_);  
     arma::mat sigma = as<arma::mat>(sigma_); 
@@ -151,10 +150,5 @@ RcppExport SEXP rmvtCpp(SEXP n_,
 
   return R_NilValue;
 
-  } catch( std::exception& __ex__){
-    forward_exception_to_r(__ex__);
-  } catch(...){
-    Rcpp::stop( "c++ exception (unknown reason)" );
-  }
-  return wrap(NA_REAL);
+  END_RCPP
 }


### PR DESCRIPTION
As a follow-up for https://github.com/mfasiolo/mvnfast/issues/16, it's better to use these Rcpp-provided macros rather than the old try/catch construct.